### PR TITLE
Changes from background agent bc-0720e863-f481-43ae-a0c1-a1545c40b963

### DIFF
--- a/specificsolutions.endowment.vue/src/@core/composable/useCookie.js
+++ b/specificsolutions.endowment.vue/src/@core/composable/useCookie.js
@@ -10,12 +10,24 @@ const CookieDefaults = {
 }
 
 export const useCookie = (name, _opts) => {
+  // Validate cookie name
+  if (!name || typeof name !== 'string') {
+    console.error('useCookie: Invalid cookie name provided:', name)
+    return ref(null)
+  }
+  
+  // Sanitize cookie name to ensure it's valid for cookies
+  const sanitizedName = name.replace(/[^a-zA-Z0-9_-]/g, '_')
+  if (sanitizedName !== name) {
+    console.warn(`useCookie: Cookie name "${name}" was sanitized to "${sanitizedName}"`)
+  }
+  
   const opts = { ...CookieDefaults, ..._opts || {} }
   const cookies = parse(document.cookie, opts)
-  const cookie = ref(cookies[name] ?? opts.default?.())
+  const cookie = ref(cookies[sanitizedName] ?? opts.default?.())
 
   watch(cookie, () => {
-    document.cookie = serializeCookie(name, cookie.value, opts)
+    document.cookie = serializeCookie(sanitizedName, cookie.value, opts)
   })
   
   return cookie

--- a/specificsolutions.endowment.vue/src/@layouts/stores/config.js
+++ b/specificsolutions.endowment.vue/src/@layouts/stores/config.js
@@ -5,7 +5,12 @@ import { _setDirAttr } from '@layouts/utils'
 // ℹ️ We should not import themeConfig here but in urgency we are doing it for now
 import { layoutConfig } from '@themeConfig'
 
-export const namespaceConfig = str => `${layoutConfig.app.title}-${str}`
+export const namespaceConfig = str => {
+  // Sanitize the app title to create valid cookie names
+  // Cookie names can only contain ASCII letters, digits, hyphens, and underscores
+  const sanitizedTitle = 'endowment-app' // Use a safe ASCII name instead of Arabic title
+  return `${sanitizedTitle}-${str}`
+}
 export const cookieRef = (key, defaultValue) => {
   return useCookie(namespaceConfig(key), { default: () => defaultValue })
 }

--- a/specificsolutions.endowment.vue/src/plugins/i18n/locales/en.json
+++ b/specificsolutions.endowment.vue/src/plugins/i18n/locales/en.json
@@ -98,5 +98,17 @@
   "eCommerce": "eCommerce",
   "Icons": "Icons",
   "Chip": "Chip",
-  "Dialog": "Dialog"
+  "Dialog": "Dialog",
+  "$vuetify": {
+    "input": {
+      "appendAction": "Append action",
+      "prependAction": "Prepend action"
+    },
+    "dataFooter": {
+      "itemsPerPageText": "Items per page:",
+      "itemsPerPageAll": "All",
+      "pageText": "{0}-{1} of {2}",
+      "noDataText": "No data available"
+    }
+  }
 }


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fixes cookie name validation and adds missing Vuetify i18n translation keys.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `TypeError: argument name is invalid` was caused by using non-ASCII characters from the app title in cookie names, which is not allowed. The app title is now sanitized to an ASCII-safe string for cookie creation. Additionally, the missing `$vuetify.input.appendAction` i18n key has been added to resolve related warnings.

---

[Open in Web](https://cursor.com/agents?id=bc-0720e863-f481-43ae-a0c1-a1545c40b963) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-0720e863-f481-43ae-a0c1-a1545c40b963) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)