### PR TITLE
Changes from background agent bc-c382214c-784c-4654-b66c-89d3a9272d71

### DIFF
--- a/specificsolutions.endowment.vue/src/plugins/i18n/locales/en.json
+++ b/specificsolutions.endowment.vue/src/plugins/i18n/locales/en.json
@@ -99,6 +99,7 @@
   "Icons": "Icons",
   "Chip": "Chip",
   "Dialog": "Dialog",
+  "إدارة الأوقاف": "Endowment Management",
   "$vuetify": {
     "input": {
       "appendAction": "Append action",


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add missing translation key "إدارة الأوقاف" to `en.json` to resolve i18n warnings.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The application was attempting to use the Arabic text 'إدارة الأوقاف' directly as a translation key in the English locale, leading to "Not found" warnings. This change provides the corresponding English translation for this specific Arabic key.

---

[Open in Web](https://cursor.com/agents?id=bc-c382214c-784c-4654-b66c-89d3a9272d71) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-c382214c-784c-4654-b66c-89d3a9272d71) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)