### PR TITLE
Show sidebar close button on minimize

### DIFF
--- a/specificsolutions.endowment.vue/src/@layouts/components/VerticalNav.vue
+++ b/specificsolutions.endowment.vue/src/@layouts/components/VerticalNav.vue
@@ -119,7 +119,11 @@ const hideTitleAndIcon = configStore.isVerticalNavMini(isHovered)
           />
           <Component
             :is="layoutConfig.app.iconRenderer || 'div'"
-            class="d-lg-none"
+            class="nav-close-btn"
+            :class="{ 
+              'd-lg-none': !configStore.isLessThanOverlayNavBreakpoint && !isOverlayNavActive,
+              'd-block': configStore.isLessThanOverlayNavBreakpoint || isOverlayNavActive 
+            }"
             v-bind="layoutConfig.icons.close"
             @click="toggleIsOverlayNavActive(false)"
           />
@@ -191,6 +195,15 @@ const hideTitleAndIcon = configStore.isVerticalNavMini(isHovered)
 
     .header-action {
       cursor: pointer;
+
+      .nav-close-btn {
+        opacity: 0.8;
+        transition: opacity 0.2s ease;
+
+        &:hover {
+          opacity: 1;
+        }
+      }
 
       @at-root {
         #{variables.$selector-vertical-nav-mini} .nav-header .header-action {


### PR DESCRIPTION
Fix sidebar close button visibility to appear on small screens and when in overlay mode.

---
<a href="https://cursor.com/background-agent?bcId=bc-f04f6e3c-4487-443a-a643-2963adec418e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f04f6e3c-4487-443a-a643-2963adec418e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>