### PR TITLE
Investigate backend validation and async handling

### DIFF
--- a/SpecificSolutions.Endowment.Application/Abstractions/Behaviors/ValidationPipelineBehavior.cs
+++ b/SpecificSolutions.Endowment.Application/Abstractions/Behaviors/ValidationPipelineBehavior.cs
@@ -5,10 +5,8 @@ using SpecificSolutions.Endowment.Application.Models.Global;
 
 public class ValidationPipelineBehavior<TRequest, TResponse> :
     IPipelineBehavior<TRequest, TResponse>
-    where TRequest : class //IRequest// notnull // IRequest<EndowmentResponse<TResponse>>
-    //where TResponse : notnull// EndowmentResponse, new()
-
-     where TResponse : EndowmentResponse
+    where TRequest : class
+    where TResponse : EndowmentResponse
 {
     private readonly IEnumerable<IValidator<TRequest>> _validators;
 
@@ -20,68 +18,37 @@ public class ValidationPipelineBehavior<TRequest, TResponse> :
         RequestHandlerDelegate<TResponse> next,
         CancellationToken cancellationToken)
     {
-        //if TRequest is not a command, then return next
-
+        // إذا لم يكن الطلب command، تابع العملية بدون validation
         if (!(request is ICommand))
         {
             return await next();
         }
 
+        // إذا لم يوجد validators، تابع العملية
         if (!_validators.Any())
         {
             return await next();
         }
 
-        if (_validators.Any())
+        // تنفيذ الـ validation
+        var context = new ValidationContext<TRequest>(request);
+
+        var validationResults = await Task.WhenAll(
+            _validators.Select(v =>
+                v.ValidateAsync(context, cancellationToken)));
+
+        var failures = validationResults
+            .Where(r => r.Errors.Any())
+            .SelectMany(r => r.Errors)
+            .ToList();
+
+        // إذا وُجدت أخطاء، ارمي ValidationException
+        if (failures.Any())
         {
-            var context = new ValidationContext<TRequest>(request);
-
-            var validationResults = await Task.WhenAll(
-                _validators.Select(v =>
-                    v.ValidateAsync(context, cancellationToken)));
-
-            var failures = validationResults
-                .Where(r => r.Errors.Any())
-                .SelectMany(r => r.Errors)
-                .ToList();
-
-            var errors = _validators
-                .Select(validator => validator.Validate(request))
-                .SelectMany(validationResult => validationResult.Errors)
-                .Where(validationFailure => validationFailure != null)
-                .Select(failure => new Error(failure.PropertyName, failure.ErrorMessage))
-                .Distinct()
-                .ToArray();
-
-            if (failures.Any())
-                throw new SpecificSolutions.Endowment.Application.Abstractions.Exceptions.ValidationException(failures);
+            throw new SpecificSolutions.Endowment.Application.Abstractions.Exceptions.ValidationException(failures);
         }
 
+        // تابع العملية إذا لم توجد أخطاء
         return await next();
-
-        //var errors = _validators
-        //    .Select(validator => validator.Validate(request))
-        //    .SelectMany(validationResult => validationResult.Errors)
-        //    .Where(validationFailure => validationFailure != null)
-        //    .Select(failure => new Error(failure.PropertyName, failure.ErrorMessage))
-        //    .Distinct()
-        //    .ToArray();
-
-        //if (errors.Any())
-        //{
-        //    return CreateValidationResult<TResponse>(errors);
-        //}
-
-        //return await next();
-    }
-
-    private static T CreateValidationResult<T>(Error[] errors) where T : EndowmentResponse, new()
-    {
-        var validationResult = new T
-        {
-            Errors = errors,
-        };
-
-        return validationResult;
     }
 }

--- a/SpecificSolutions.Endowment.Application/Abstractions/Exceptions/GlobalExceptionHandler.cs
+++ b/SpecificSolutions.Endowment.Application/Abstractions/Exceptions/GlobalExceptionHandler.cs
@@ -30,27 +30,22 @@ namespace SpecificSolutions.Endowment.Application.Handlers
 
         public async ValueTask<bool> TryHandleAsync(HttpContext httpContext, Exception exception, CancellationToken cancellationToken)
         {
-            //var errorCode = exception switch
-            //{
-            //    EntityNotFoundException => (int)HttpStatusCode.BadRequest + "01",
-            //    ValidationException => (int)HttpStatusCode.BadRequest + "02",
-            //    _ => (int)HttpStatusCode.InternalServerError + "00"
-            //};
-
             var exceptionType = exception.GetType();
 
             if (_exceptionHandlers.ContainsKey(exceptionType))
             {
                 await _exceptionHandlers[exceptionType].Invoke(httpContext, exception, cancellationToken);
-                return false;
+                return true; // إصلاح: يجب إرجاع true عندما يتم التعامل مع الـ exception
             }
 
-            return true;
+            return false; // إرجاع false فقط عندما لا يتم التعامل مع الـ exception
         }
 
         private async Task HandleValidationException(HttpContext httpContext, Exception ex, CancellationToken cancellationToken)
         {
             var exception = (ValidationException)ex;
+
+            _logger.LogWarning(exception, "Validation errors occurred.");
 
             // تحويل Dictionary<string, string[]> إلى Errors
             var errors = exception.Errors
@@ -58,58 +53,46 @@ namespace SpecificSolutions.Endowment.Application.Handlers
                 .ToArray();
 
             var response = new EndowmentResponse(state: ResponseState.BadRequest, "Validation failed", errors);
+            
             httpContext.Response.ContentType = "application/json";
             httpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
 
             await httpContext.Response.WriteAsJsonAsync<EndowmentResponse>(response, cancellationToken);
         }
 
-        private async Task<EndowmentResponse> HandleNotFoundException(HttpContext httpContext, Exception ex, CancellationToken cancellationToken)
+        private async Task HandleNotFoundException(HttpContext httpContext, Exception ex, CancellationToken cancellationToken)
         {
             var exception = (NotFoundException)ex;
+
+            _logger.LogWarning(exception, "Resource not found: {Message}", exception.Message);
 
             httpContext.Response.ContentType = "application/json";
             httpContext.Response.StatusCode = StatusCodes.Status404NotFound;
 
-            await httpContext.Response.WriteAsJsonAsync(new ProblemDetails()
-            {
-                Status = StatusCodes.Status404NotFound,
-                Type = "https://tools.ietf.org/html/rfc7231#section-6.5.4",
-                Title = "The specified resource was not found.",
-                Detail = exception.Message
-            });
-
-            return await Task.FromResult(new EndowmentResponse(ResponseState.NotFound, exception.Message, null));
+            var response = new EndowmentResponse(ResponseState.NotFound, exception.Message, null);
+            await httpContext.Response.WriteAsJsonAsync<EndowmentResponse>(response, cancellationToken);
         }
 
-        private async Task<EndowmentResponse> HandleUnauthorizedAccessException(HttpContext httpContext, Exception ex, CancellationToken cancellationToken)
+        private async Task HandleUnauthorizedAccessException(HttpContext httpContext, Exception ex, CancellationToken cancellationToken)
         {
+            _logger.LogWarning(ex, "Unauthorized access attempt.");
+
             httpContext.Response.ContentType = "application/json";
             httpContext.Response.StatusCode = StatusCodes.Status401Unauthorized;
 
-            await httpContext.Response.WriteAsJsonAsync(new ProblemDetails
-            {
-                Status = StatusCodes.Status401Unauthorized,
-                Title = "Unauthorized",
-                Type = "https://tools.ietf.org/html/rfc7231#section-6.5.3"
-            });
-
-            return await Task.FromResult(new EndowmentResponse(ResponseState.Unauthorized, ex.Message, null));
+            var response = new EndowmentResponse(ResponseState.Unauthorized, ex.Message, null);
+            await httpContext.Response.WriteAsJsonAsync<EndowmentResponse>(response, cancellationToken);
         }
 
-        private async Task<EndowmentResponse> HandleForbiddenAccessException(HttpContext httpContext, Exception ex, CancellationToken cancellationToken)
+        private async Task HandleForbiddenAccessException(HttpContext httpContext, Exception ex, CancellationToken cancellationToken)
         {
+            _logger.LogWarning(ex, "Forbidden access attempt.");
+
             httpContext.Response.ContentType = "application/json";
             httpContext.Response.StatusCode = StatusCodes.Status403Forbidden;
 
-            await httpContext.Response.WriteAsJsonAsync(new ProblemDetails
-            {
-                Status = StatusCodes.Status403Forbidden,
-                Title = "Forbidden",
-                Type = "https://tools.ietf.org/html/rfc7231#section-6.5.3"
-            });
-
-            return await Task.FromResult(new EndowmentResponse(ResponseState.Forbidden, ex.Message, null));
+            var response = new EndowmentResponse(ResponseState.Forbidden, ex.Message, null);
+            await httpContext.Response.WriteAsJsonAsync<EndowmentResponse>(response, cancellationToken);
         }
 
         private async Task HandleConcurrencyException(HttpContext httpContext, Exception ex, CancellationToken cancellationToken)
@@ -120,13 +103,9 @@ namespace SpecificSolutions.Endowment.Application.Handlers
 
             httpContext.Response.ContentType = "application/json";
             httpContext.Response.StatusCode = (int)HttpStatusCode.Conflict; // 409 Conflict
-            await httpContext.Response.WriteAsJsonAsync(new ProblemDetails
-            {
-                Status = (int)HttpStatusCode.Conflict,
-                Title = "Concurrency conflict",
-                Detail = "The data you are trying to update has been modified by another user. Please refresh and try again.",
-                Type = "https://tools.ietf.org/html/rfc7231#section-6.5.8"
-            });
+            
+            var response = new EndowmentResponse(ResponseState.BadRequest, "The data you are trying to update has been modified by another user. Please refresh and try again.", null);
+            await httpContext.Response.WriteAsJsonAsync<EndowmentResponse>(response, cancellationToken);
         }
     }
 }


### PR DESCRIPTION
Standardize API error responses and streamline the validation pipeline to correctly return FluentValidation errors to the frontend.

The previous `GlobalExceptionHandler` incorrectly returned `false` after handling exceptions and used inconsistent `ProblemDetails` for some errors, preventing consistent error propagation to the frontend. The `ValidationPipelineBehavior` also contained redundant validation logic. These changes ensure that FluentValidation errors are consistently captured, processed, and returned in a standardized `EndowmentResponse` format, allowing the frontend to display specific field-level validation messages.

---
<a href="https://cursor.com/background-agent?bcId=bc-bd90711b-9528-4f69-b8aa-32ce9b7e2629">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bd90711b-9528-4f69-b8aa-32ce9b7e2629">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>