### PR TITLE
Check construction request permissions from cookie

### DIFF
--- a/specificsolutions.endowment.vue/src/App.vue
+++ b/specificsolutions.endowment.vue/src/App.vue
@@ -31,8 +31,8 @@ onBeforeMount(() => {
   if (typeof window !== 'undefined') {
     window.addEventListener('beforeunload', () => {
       // حفظ الصلاحيات قبل إغلاق الصفحة
-      const userAbilityRules = useCookie('user-ability-rules')
-      if (userAbilityRules.value) {
+      const userAbilityRules = localStorage.getItem('user-ability-rules')
+      if (userAbilityRules) {
         console.log('💾 Saving ability rules before page unload')
       }
     })

--- a/specificsolutions.endowment.vue/src/pages/login.vue
+++ b/specificsolutions.endowment.vue/src/pages/login.vue
@@ -186,16 +186,51 @@ const login = async () => {
     console.log('CASL Rules المحدثة:', rules)
     console.log('User permissions من Backend:', user.permissions)
 
-    // حفظ قواعد الصلاحيات في الكوكيز لاستعادتها بعد إعادة التحميل
-    const abilityRulesCookie = useCookie('user-ability-rules', {
-      default: () => [],
-      maxAge: 60 * 60 * 24 * 7, // 7 days
-      path: '/',
-      secure: true,
-      sameSite: 'strict'
+    // حفظ قواعد الصلاحيات في localStorage بدلاً من الكوكيز لتجنب مشكلة الحجم
+    console.log('🔍 Rules before saving to localStorage:', rules.length, 'rules')
+    console.log('🔍 Rules details before saving:')
+    rules.forEach((rule, index) => {
+      console.log(`  ${index + 1}. Action: ${rule.action}, Subject: ${rule.subject}`)
     })
-    abilityRulesCookie.value = rules
-    console.log('🍪 Saved ability rules to cookie:', abilityRulesCookie.value)
+    
+    // حفظ الصلاحيات في localStorage
+    try {
+      localStorage.setItem('user-ability-rules', JSON.stringify(rules))
+      console.log('✅ Saved ability rules to localStorage:', rules.length, 'rules')
+      
+      // إضافة debugging إضافي لمعرفة الصلاحيات المحفوظة
+      console.log('🔍 ConstructionRequest permissions in localStorage:')
+      const constructionRequestInStorage = rules.filter(rule => 
+        rule.subject === 'ConstructionRequest'
+      )
+      console.log('ConstructionRequest rules in localStorage:', constructionRequestInStorage)
+      
+      // إضافة debugging لمعرفة جميع الصلاحيات في localStorage
+      console.log('🔍 All permissions in localStorage:')
+      rules.forEach((rule, index) => {
+        console.log(`  ${index + 1}. Action: ${rule.action}, Subject: ${rule.subject}`)
+      })
+      
+      // إضافة debugging لمعرفة حجم البيانات
+      const storageString = JSON.stringify(rules)
+      console.log('🔍 LocalStorage size:', storageString.length, 'characters')
+      console.log('🔍 LocalStorage string preview:', storageString.substring(0, 200) + '...')
+      
+      // إضافة debugging لمعرفة ما إذا كان هناك مشكلة في الترميز
+      console.log('🔍 LocalStorage encoding check:')
+      const decodedStorage = JSON.parse(storageString)
+      console.log('✅ LocalStorage can be parsed successfully')
+      console.log('🔍 Decoded localStorage length:', decodedStorage.length, 'rules')
+      
+      // فحص الصلاحيات المفقودة
+      const missingSubjects = ['AccountDetail', 'ConstructionRequest', 'MaintenanceRequest', 'ChangeRequest']
+      missingSubjects.forEach(subject => {
+        const found = decodedStorage.filter(rule => rule.subject === subject)
+        console.log(`🔍 ${subject} rules in decoded localStorage:`, found.length)
+      })
+    } catch (error) {
+      console.error('❌ Error saving to localStorage:', error)
+    }
     
     ability.update(rules)
     console.log('✅ Updated CASL ability with rules')

--- a/specificsolutions.endowment.vue/src/plugins/1.router/guards.js
+++ b/specificsolutions.endowment.vue/src/plugins/1.router/guards.js
@@ -56,20 +56,37 @@ export const setupGuards = router => {
         return true
       }
 
-      // الحصول على قواعد الصلاحيات من الكوكيز
-      const userAbilityRules = useCookie('user-ability-rules', {
-        default: () => [],
-        maxAge: 60 * 60 * 24 * 7, // 7 days
-        path: '/',
-        secure: true,
-        sameSite: 'strict'
-      }).value
-      console.log('🔍 User ability rules from cookie:', userAbilityRules)
-      
-      if (!userAbilityRules || !Array.isArray(userAbilityRules)) {
-        console.warn('❌ No ability rules found or invalid format')
-        return false
+      // Get user ability rules from localStorage
+      let userAbilityRules = []
+      try {
+        const storedRules = localStorage.getItem('user-ability-rules')
+        if (storedRules) {
+          userAbilityRules = JSON.parse(storedRules)
+        }
+      } catch (error) {
+        console.error('❌ Error reading from localStorage:', error)
+        userAbilityRules = []
       }
+      
+      // إضافة debugging لمعرفة الصلاحيات المقروءة من localStorage
+      console.log('🔍 Reading permissions from localStorage:', userAbilityRules.length, 'rules')
+      console.log('🔍 LocalStorage permissions details:')
+      userAbilityRules.forEach((rule, index) => {
+        console.log(`  ${index + 1}. Action: ${rule.action}, Subject: ${rule.subject}`)
+      })
+      
+      // إضافة debugging لمعرفة ما إذا كان هناك مشكلة في قراءة localStorage
+      console.log('🔍 LocalStorage reading check:')
+      const storageString = JSON.stringify(userAbilityRules)
+      console.log('🔍 LocalStorage string length:', storageString.length, 'characters')
+      console.log('🔍 LocalStorage string preview:', storageString.substring(0, 200) + '...')
+      
+      // فحص الصلاحيات المفقودة
+      const missingSubjects = ['AccountDetail', 'ConstructionRequest', 'MaintenanceRequest', 'ChangeRequest']
+      missingSubjects.forEach(subject => {
+        const found = userAbilityRules.filter(rule => rule.subject === subject)
+        console.log(`🔍 ${subject} rules in guards:`, found.length)
+      })
 
       // إنشاء ability مؤقت للتحقق
       const ability = createMongoAbility(userAbilityRules)

--- a/specificsolutions.endowment.vue/src/plugins/casl/ability.js
+++ b/specificsolutions.endowment.vue/src/plugins/casl/ability.js
@@ -2,27 +2,31 @@ import { createMongoAbility } from '@casl/ability'
 
 export const ability = createMongoAbility()
 
-// دالة لإعادة تحميل الصلاحيات من الكوكيز
-export const reloadAbilityFromCookie = () => {
+// دالة لإعادة تحميل الصلاحيات من localStorage
+export const reloadAbilityFromLocalStorage = () => {
   try {
-    const userAbilityRules = useCookie('user-ability-rules', {
-      default: () => [],
-      maxAge: 60 * 60 * 24 * 7, // 7 days
-      path: '/',
-      secure: true,
-      sameSite: 'strict'
-    }).value
-
-    if (userAbilityRules && Array.isArray(userAbilityRules)) {
-      ability.update(userAbilityRules)
-      console.log('✅ Reloaded ability from cookie:', userAbilityRules)
-      return true
+    const storedRules = localStorage.getItem('user-ability-rules')
+    
+    if (storedRules) {
+      const userAbilityRules = JSON.parse(storedRules)
+      
+      if (userAbilityRules && Array.isArray(userAbilityRules)) {
+        ability.update(userAbilityRules)
+        console.log('✅ Reloaded ability from localStorage:', userAbilityRules)
+        return true
+      } else {
+        console.warn('❌ Invalid ability rules format in localStorage')
+        return false
+      }
     } else {
-      console.warn('❌ No valid ability rules found in cookie')
+      console.warn('❌ No ability rules found in localStorage')
       return false
     }
   } catch (error) {
-    console.error('❌ Error reloading ability from cookie:', error)
+    console.error('❌ Error reloading ability from localStorage:', error)
     return false
   }
 }
+
+// Keep the old function name for backward compatibility but use localStorage
+export const reloadAbilityFromCookie = reloadAbilityFromLocalStorage

--- a/specificsolutions.endowment.vue/src/plugins/casl/index.js
+++ b/specificsolutions.endowment.vue/src/plugins/casl/index.js
@@ -1,16 +1,21 @@
 import { createMongoAbility } from '@casl/ability'
 import { abilitiesPlugin } from '@casl/vue'
-import { reloadAbilityFromCookie } from './ability'
+import { reloadAbilityFromLocalStorage } from './ability'
 
 export default function (app) {
-  const userAbilityRules = useCookie('user-ability-rules', {
-    default: () => [],
-    maxAge: 60 * 60 * 24 * 7, // 7 days
-    path: '/',
-    secure: true,
-    sameSite: 'strict'
-  })
-  const initialAbility = createMongoAbility(userAbilityRules.value ?? [])
+  // قراءة الصلاحيات من localStorage
+  let userAbilityRules = []
+  try {
+    const storedRules = localStorage.getItem('user-ability-rules')
+    if (storedRules) {
+      userAbilityRules = JSON.parse(storedRules)
+    }
+  } catch (error) {
+    console.error('❌ Error reading from localStorage in index.js:', error)
+    userAbilityRules = []
+  }
+  
+  const initialAbility = createMongoAbility(userAbilityRules ?? [])
 
   app.use(abilitiesPlugin, initialAbility, {
     useGlobalProperties: true,
@@ -18,9 +23,9 @@ export default function (app) {
 
   // إعادة تحميل الصلاحيات عند تحميل التطبيق
   if (typeof window !== 'undefined') {
-    // تأخير قليل للتأكد من تحميل الكوكيز
+    // تأخير قليل للتأكد من تحميل localStorage
     setTimeout(() => {
-      reloadAbilityFromCookie()
+      reloadAbilityFromLocalStorage()
     }, 100)
   }
 }


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Migrate user ability rules storage from cookies to localStorage to prevent data truncation.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, large sets of user permissions were being truncated when stored in cookies due to browser size limitations. This resulted in missing abilities (e.g., ConstructionRequest) and subsequent access denied errors. Switching to localStorage resolves this by providing a larger storage capacity.

---
<a href="https://cursor.com/background-agent?bcId=bc-19e7e51d-3ccf-4f58-86f9-ec74a3f9138f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-19e7e51d-3ccf-4f58-86f9-ec74a3f9138f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>