### PR TITLE
Changes from background agent bc-e0cd641e-20c9-4063-8832-9dec999af7a4

### DIFF
--- a/specificsolutions.endowment.vue/src/plugins/i18n/locales/en.json
+++ b/specificsolutions.endowment.vue/src/plugins/i18n/locales/en.json
@@ -456,6 +456,7 @@
     }
   },
   "$vuetify": {
+    "badge": "Badge",
     "input": {
       "appendAction": "Append action",
       "prependAction": "Prepend action"


### PR DESCRIPTION
Add missing `$vuetify.badge` translation key to resolve console error.

---
<a href="https://cursor.com/background-agent?bcId=bc-e0cd641e-20c9-4063-8832-9dec999af7a4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e0cd641e-20c9-4063-8832-9dec999af7a4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>